### PR TITLE
UI fix directory list divide li

### DIFF
--- a/components/layout/directory.tsx
+++ b/components/layout/directory.tsx
@@ -74,7 +74,7 @@ export default function Directory({
               <div className="bg-dark-accent-1 px-6 py-1 text-sm font-bold text-white uppercase">
                 <h3>{letter}</h3>
               </div>
-              <ul role="list" className="relative z-0">
+              <ul role="list" className="relative z-0 directory-divide-y">
                 {users.map((user) => (
                   <li key={user.username}>
                     <Link href={`/${user.username}`}>
@@ -108,7 +108,6 @@ export default function Directory({
                               @{user.username}
                             </p>
                           </div>
-                          <div className="w-full left-3 bg-dark-accent-2 bottom-0 h-[1px] absolute" />
                         </div>
                       </a>
                     </Link>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,14 @@
 @tailwind base;
+
+.directory-divide-y > li:not(:last-child):after {
+  content: '';
+  display: block;
+  width: calc(100% - 24px);
+  transform: translateX(24px);
+  height: 1px;
+  background: #333333;
+}
+
 @tailwind components;
 @tailwind utilities;
 


### PR DESCRIPTION
Hi,
This is another great Starter by your team 👍 

This fix for only displays the divide on directory list when there are several developers per letter:

![Fix directory divide li](https://user-images.githubusercontent.com/3640689/172737432-bf6c4c99-d2f1-451b-b54e-68e88877fdf8.png)

Have a good day