### PR TITLE
Added error check, reminding to run setup first

### DIFF
--- a/lib/api/user.ts
+++ b/lib/api/user.ts
@@ -67,6 +67,11 @@ export async function getFirstUser(): Promise<UserProps | null> {
       projection: { _id: 0, emailVerified: 0 }
     }
   );
+
+  if (!results) {
+    throw new Error('Please run "npm run setup" to insert testing records');
+  }
+
   return {
     ...results,
     bioMdx: await getMdxSource(results.bio || placeholderBio)
@@ -123,7 +128,7 @@ export async function searchUser(query: string): Promise<UserProps[]> {
       {
         $search: {
           index: 'name-index',
-          /* 
+          /*
           name-index is a search index as follows:
 
           {


### PR DESCRIPTION
## Discovery
I was testing this repository locally, so I skipped the follwing a step to setup testing records

```sh
npm run setup
```

I was getting this error
```
TypeError: Cannot read properties of null (reading 'bio')
  71 |   return {
  72 |     ...results,
> 73 |     bioMdx: await getMdxSource(results.bio || placeholderBio)
     |                                       ^
  74 |   };
  75 | }
  76 |
```

## Solution
I added a check and remind the user to run ```npm run setup``` first.