### PR TITLE
Reuse connections in production

### DIFF
--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -22,7 +22,7 @@ if (process.env.NODE_ENV === 'development') {
     global._mongoClientPromise = client.connect();
   }
   clientPromise = global._mongoClientPromise;
-} else {
+} else if(!client || !clientPromise) {
   // In production mode, it's best to not use a global variable.
   client = new MongoClient(uri, options);
   clientPromise = client.connect();


### PR DESCRIPTION
Instead of creating MongoClient on each invocation, only create when there are no instances.